### PR TITLE
[feat] 필터 새로고침 시에도 유지(로그인 X 상태), 로딩 스피너 교체

### DIFF
--- a/src/components/GlobalComponents/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/GlobalComponents/LoadingSpinner/LoadingSpinner.tsx
@@ -1,16 +1,35 @@
-import spinner from '../../../../public/assets/spinner.gif';
+import spinner from 'public/assets/logo.png';
 import Image from 'next/image';
+import styled, { keyframes } from 'styled-components';
 
 const LoadingSpinner = () => {
   return (
-    <Image
-      src={spinner}
-      alt="spinner"
-      height={60}
-      quality={75}
-      priority={true}
-    />
+    <Loading>
+      <Image
+        className="loader"
+        src={spinner}
+        alt="spinner"
+        height={80}
+        quality={75}
+        priority={true}
+      />
+    </Loading>
   );
 };
 
 export default LoadingSpinner;
+
+const slideDown = keyframes`
+0%{
+    transform: translateY(-10%)
+}
+100%{
+    transform: translateY(15%);
+}
+`;
+
+const Loading = styled.div`
+  .loader {
+    animation: ${slideDown} 0.7s linear infinite alternate;
+  }
+`;

--- a/src/components/MainPage/CategoryBar/CategoryBar.tsx
+++ b/src/components/MainPage/CategoryBar/CategoryBar.tsx
@@ -20,6 +20,10 @@ const CategoryBar = ({ expanded }: ExpandedJ) => {
   const [isTypeToggleOpen, setIsTypeToggleOpen] = useState<boolean>(false);
   const [currentTab, SetCurrentTab] = useState<number>(0);
 
+  // 유저가 선택한 필터 LocalStorage에 저장
+  const LS_REGION_KEY = 'LS_REGION_KEY';
+  const LS_TYPE_KEY = 'LS_TYPE_KEY';
+
   // 로그인 여부 확인
   const { data: session }: any = useSession();
 
@@ -44,13 +48,14 @@ const CategoryBar = ({ expanded }: ExpandedJ) => {
   const [myRegionArray, setMyRegionArray] = useState<any>([]);
   const [myTypeArray, setMyTypeArray] = useState<any>([]);
 
-  useEffect(() => {
-    if (currentUser) {
-      setMyRegionArray(userRegionArray);
-      setMyTypeArray(userTypeArray);
-    }
-    // eslint-disable-next-line
-  }, [userRegionArray, userTypeArray]);
+  // 로그인 시 유저가 선택한 지역 및 관심형태
+  // useEffect(() => {
+  //   if (currentUser) {
+  //     setMyRegionArray(userRegionArray);
+  //     setMyTypeArray(userTypeArray);
+  //   }
+  //   // eslint-disable-next-line
+  // }, [userRegionArray, userTypeArray]);
 
   // 선택한 지역, 분양형태가 바뀔 때마다 recoil defaultValue를 업데이트
   const [selectedRegionArray, setSelectedRegionArray] =
@@ -59,10 +64,21 @@ const CategoryBar = ({ expanded }: ExpandedJ) => {
     useRecoilState(selectedTypeList);
 
   useEffect(() => {
-    setSelectedRegionArray(myRegionArray);
-    setSelectedTypeArray(myTypeArray);
+    if (myRegionArray.length > 0) {
+      localStorage.setItem(LS_REGION_KEY, myRegionArray);
+    }
+
+    const regionLS = localStorage.getItem(LS_REGION_KEY);
+
+    if (regionLS !== null) {
+      setSelectedRegionArray(myRegionArray);
+      setSelectedTypeArray(myTypeArray);
+    }
+
     // eslint-disable-next-line
   }, [myRegionArray, myTypeArray]);
+
+  console.log('ls', localStorage.getItem(LS_REGION_KEY));
 
   // 지역, 분양형태 카테고리 Tabs를 누를 때마다 Open, Close 전환
   const openToggleHandler = () => {

--- a/src/components/MainPage/CountTabs/CountTabs.tsx
+++ b/src/components/MainPage/CountTabs/CountTabs.tsx
@@ -287,9 +287,7 @@ const CountTabs = ({ list, expanded }: CountTabPropsListJ) => {
         </S.CountSectionBack>
         <CategoryBar expanded={expanded} />
       </S.TapContainer>
-      {/* 분양 정보가 없을 때 보여줄 문구 */}
-      {isLoading ? null : // <LoadingSpinner /> 이건 지우는게 좋을것 같아요
-      tabList[currentTab].content.length === 0 ? (
+      {isLoading ? null : tabList[currentTab].content.length === 0 ? (
         <div
           style={{
             paddingTop: '12%',
@@ -300,6 +298,7 @@ const CountTabs = ({ list, expanded }: CountTabPropsListJ) => {
             backgroundColor: '#f7f7f7',
           }}
         >
+          {/* 분양 정보가 없을 때 보여줄 문구 */}
           <NoResult
             title="현재 설정하신 필터에 해당되는 분양 정보가 없습니다."
             text="다른 지역 및 분양 형태를 찾아보세요."

--- a/src/components/MyPage/EditProfile/EditProfile.tsx
+++ b/src/components/MyPage/EditProfile/EditProfile.tsx
@@ -31,6 +31,8 @@ const EditProfile = ({ currentUser }: any) => {
         );
       },
     });
+    // 로그아웃 시 sessionStorage를 삭제하면 메인에서 전체 리스트가 보임
+    sessionStorage.clear();
   };
 
   return (

--- a/src/components/MyPage/MyTabs/MyTabs.tsx
+++ b/src/components/MyPage/MyTabs/MyTabs.tsx
@@ -74,7 +74,12 @@ const MyTabs = () => {
       <S.TabContentContainer>
         {/* 북마크 목록 */}
         {currentTab === 1 && (
-          <S.BookmarkListContainer style={{justifyContent: myBookmarkList?.length === 0 ? "center" : "flex-start"}}>
+          <S.BookmarkListContainer
+            style={{
+              justifyContent:
+                myBookmarkList?.length === 0 ? 'center' : 'flex-start',
+            }}
+          >
             {!myBookmarkList ? null : myBookmarkList?.length === 0 ? (
               <S.NoResultContainer>
                 <NoResult


### PR DESCRIPTION
## 개요
- 필터 새로고침 시에도 유지(로그인 X 상태)
- 로딩 스피너 교체

## 작업사항
- (로그인 하지 않았을 때만)새로 고침 시에도 지역 및 분양형태 필터 유지
- 로그인 했을 때는 유저의 관심 필터가 반영되는데 필터를 변경했을 때 새로 고침 시에도 유지되는 건 아직 구현 못했습니다. 
- 로딩 스피너 로고 이미지로 교체 후 위아래로 bounce되는 애니메이션 추가했습니다. 