### PR TITLE
[feat] 아파트 매매 실거래가 API 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const SERVICE_KEY = process.env.NEXT_PUBLIC_HOME_API_KEY;
-const MAP_KEY = process.env.NEXT_PUBLIC_NCP_CLIENT_ID;
 
 module.exports = {
   // <Image> 사용 시 어떤 출처의 외부 이미지든 사용 가능함
@@ -28,14 +26,6 @@ module.exports = {
         source: '/admin',
         destination: '/',
         permanent: false,
-      },
-    ];
-  },
-  async rewrites() {
-    return [
-      {
-        source: '/api/APTRealPrice/:id/:contractMonth',
-        destination: `http://openapi.molit.go.kr/OpenAPI_ToolInstallPackage/service/rest/RTMSOBJSvc/getRTMSDataSvcAptTradeDev?numOfRows=1000&LAWD_CD=:id&DEAL_YMD=:contractMonth&serviceKey=${SERVICE_KEY}`,
       },
     ];
   },

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -93,7 +93,7 @@ export const getProfile = async (email: string | null | undefined) => {
 export const getAPTRealPriceList = async (id: any, contractMonth: string) => {
   const data = await axios
     .get(`/api/APTRealPrice/${id?.split(':')[0]}/${contractMonth}`)
-    .then((res) => res.data.response.body.items.item);
+    .then((res) => res.data.items);
   return data;
 };
 

--- a/src/components/DetailPage/APTRealPrice/APTRealPrice.tsx
+++ b/src/components/DetailPage/APTRealPrice/APTRealPrice.tsx
@@ -2,22 +2,6 @@ import NoResult from '@/components/GlobalComponents/NoResult/NoResult';
 import * as S from './style';
 
 const APTRealPrice = ({ dongList }: any) => {
-  // 유효성 검사 위한 주석이니 삭제하지 말아 주세요😇
-  // console.log(
-  //   '디테일 페이지 동 주소:',
-  //   detail.HSSPLY_ADRES.split('(').length > 1
-  //     ? detail.HSSPLY_ADRES.split('(')[1].slice(0, 3)
-  //     : detail.HSSPLY_ADRES.split(' ')[2],
-  // );
-
-  // 유효성 검사 위한 주석이니 삭제하지 말아 주세요😇
-  // APTRealPriceList?.map((item: any) =>
-  //   console.log(
-  //     item.법정동.split(' ')[0] === ''
-  //       ? item.법정동.split(' ')[1]
-  //       : item.법정동.split(' ')[0],
-  //   ),
-  // );
 
   return (
     <S.Wrapper>
@@ -34,7 +18,7 @@ const APTRealPrice = ({ dongList }: any) => {
             <S.TableRow>
               <S.TableHead>계약일</S.TableHead>
               <S.TableHead>아파트명</S.TableHead>
-              <S.TableHead>주소</S.TableHead>
+              <S.TableHead>법정동</S.TableHead>
               <S.TableHead>전용면적</S.TableHead>
               <S.TableHead>거래금액</S.TableHead>
             </S.TableRow>
@@ -43,18 +27,19 @@ const APTRealPrice = ({ dongList }: any) => {
             <tbody key={index}>
               <S.TableRow>
                 <S.TableData>
-                  {item.년}-
-                  {item.월.toString().length === 1 ? `0${item.월}` : item.월}-
-                  {item.일.toString().length === 1 ? `0${item.일}` : item.일}
+                  {item.dealYear}-
+                  {item.dealMonth.toString().length === 1 ? `0${item.dealMonth}` : item.dealMonth}-
+                  {item.dealDay.toString().length === 1 ? `0${item.dealDay}` : item.dealDay}
                 </S.TableData>
                 <S.TableData>
-                  <div>{item.아파트}</div> <span>({item.층}층)</span>
+                  <div>{item.aptNm}</div> <span>({item.floor}층)</span>
                 </S.TableData>
                 <S.TableData>
-                  {item.법정동} {item.도로명}
+                  {item.umdNm} 
+                  {/* {item.도로명} */}
                 </S.TableData>
-                <S.TableData>{item.전용면적}㎡</S.TableData>
-                <S.TableData>{item.거래금액}만원</S.TableData>
+                <S.TableData>{item.excluUseAr}㎡</S.TableData>
+                <S.TableData>{item.dealAmount}만 원</S.TableData>
               </S.TableRow>
             </tbody>
           ))}

--- a/src/components/DetailPage/PostDetail/PostDetail.tsx
+++ b/src/components/DetailPage/PostDetail/PostDetail.tsx
@@ -84,19 +84,10 @@ const PostDetail = ({ postId, detail }: DetailPagePropsP) => {
     {
       enabled: !!LAWD_CD, // LAWD_CD이 있는 경우에만 useQuery를 실행함
 
-      // 지역코드로 불러온 아파트 매매 실거래가 리스트에서 '읍면동' 기준으로 필터링하기
+      // 지역코드로 불러온 아파트 매매 실거래가 내림차순 정렬
       onSuccess: (APTRealPriceList: any) => {
         setDongList(
-          APTRealPriceList?.filter((item: any) =>
-            (detail.HSSPLY_ADRES.split('(').length > 1
-              ? detail.HSSPLY_ADRES.split('(')[1].slice(0, 3)
-              : detail.HSSPLY_ADRES.split(' ')[2]
-            ).includes(
-              item.법정동.split(' ')[0] === ''
-                ? item.법정동.split(' ')[1]
-                : item.법정동.split(' ')[0],
-            ),
-          ).reverse(),
+          APTRealPriceList.sort((a: any, b: any) => b.dealDay - a.dealDay),
         );
       },
     },

--- a/src/pages/api/APTRealPrice/[id]/[contractMonth].ts
+++ b/src/pages/api/APTRealPrice/[id]/[contractMonth].ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { id, contractMonth } = req.query;
+  const SERVICE_KEY = process.env.NEXT_PUBLIC_APT_API_KEY;
+
+  try {
+    const response = await axios.get(
+      'https://apis.data.go.kr/1613000/RTMSDataSvcAptTrade/getRTMSDataSvcAptTrade',
+      {
+        params: {
+          serviceKey: SERVICE_KEY,
+          numOfRows: 200,
+          LAWD_CD: id,
+          DEAL_YMD: contractMonth,
+        },
+      },
+    );
+    const items = response.data.response.body.items.item || [];
+    res.status(200).json({ id, contractMonth, items });
+  } catch (error) {
+    if (error instanceof Error) {
+      res.status(500).json({ error: error.message, id, contractMonth });
+    } else {
+      res
+        .status(500)
+        .json({ error: 'An unexpected error occurred', id, contractMonth });
+    }
+  }
+}


### PR DESCRIPTION
## 개요 🔎
- 기존에 사용하던 아파트 매매 실거래자료 OPEN API가 중지돼서 [신규 API](https://www.data.go.kr/data/15126469/openapi.do#/API%20%EB%AA%A9%EB%A1%9D/getRTMSDataSvcAptTrade)로 교체했습니다.
- 기존에 `rewrites` 기능을 사용해서 API를 호출하던 로직을 `API Routes`를 사용하는 것으로 변경했습니다.

</br>

## 작업사항 📝
```javascript
// next.config.js
module.exports = {  
	async rewrites() {
      return [
        {
          source: '/api/APTRealPrice/:id/:contractMonth',
          destination: `https://apis.data.go.kr/1613000/RTMSDataSvcAptTrade/getRTMSDataSvcAptTrade?numOfRows=1000&LAWD_CD=:id&DEAL_YMD=:contractMonth&serviceKey=${SERVICE_KEY}`,
        },
      ];
    },
}
```
- `API KEY`를 노출하지 않기 위해 Next.js의 `rewrites` 기능을 사용해 요청 경로를 다른 경로로 매핑하고 있었음
- 신규 API로 변경하는 과정에서 `API KEY`를 새로 발급받았는데 어떤 방법을 사용해도 `SERVICE_KEY_IS_NOT_REGISTERED_ERROR` 에러가 발생하는 것을 해결할 수 없었음
- `rewrites` 대신에 `API Routes` 기능으로 API를 생성해서 `API KEY`가 노출되지 않도록 방법을 변경함

</br>

![image](https://github.com/user-attachments/assets/a9547b98-2318-4456-8f25-1ad3a6c0f83a)
- `pages/api/APTRealPrice/[id]/[contractMonth].ts` 경로로 API를 구축해서 `API KEY` 노출 없이 API를 호출하는 데 성공함